### PR TITLE
Stream a single partition to stdout with -o -

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Android OTA updates ship as a `payload.bin` inside a firmware ZIP. That file con
 - **Stream from a URL** with HTTP range requests — extract `boot.img` out of a 4 GB OTA without downloading the whole thing.
 - **Read straight from OTA `.zip`** — no `unzip` step required; operates on the stored `payload.bin` member in place.
 - **Parallel extraction** across partitions with a live per-partition progress UI.
+- **Pipe to stdout** with `-o -` for composition with `simg2img`, `fastboot`, and other tools.
 - **`--json` output** for scripting and CI integration.
 
 ## Prerequisites
@@ -89,6 +90,18 @@ payload-dumper payload.bin -p boot system vendor
 payload-dumper payload.bin -o extracted/
 ```
 
+### Stream a single partition to stdout
+
+Use `-o -` to pipe one partition's image into another tool without touching disk. Requires exactly one partition via `-p`; progress and banners go to stderr so stdout stays pure image bytes.
+
+```bash
+# Flash boot directly from a remote OTA
+payload-dumper https://dl.example.com/ota.zip -p boot -o - | fastboot flash boot -
+
+# Convert a sparse system image on the fly
+payload-dumper payload.bin -p system -o - | simg2img - system.raw
+```
+
 ### Control parallelism
 
 ```bash
@@ -130,7 +143,7 @@ payload-dumper [-h] [-o OUTPUT] [-p NAME ...] [-l] [--json] [-j WORKERS] [-V] pa
 | Option | Description |
 |---|---|
 | `payload` | Path or URL to `payload.bin` or an OTA `.zip` containing it (required) |
-| `-o`, `--output DIR` | Output directory for extracted images (default: `output/`) |
+| `-o`, `--output DIR` | Output directory for extracted images (default: `output/`). Use `-` to stream a single partition to stdout (requires `-p NAME`). |
 | `-p`, `--partitions NAME [NAME ...]` | Extract only the listed partitions |
 | `-l`, `--list` | List all partitions in the payload and exit |
 | `--json` | With `--list`, emit JSON to stdout instead of a table |

--- a/src/payload_dumper/__init__.py
+++ b/src/payload_dumper/__init__.py
@@ -5,6 +5,7 @@ from .core import (
     PayloadError,
     UnsupportedPayloadError,
     extract_partition,
+    extract_partition_to_stream,
     parse_payload,
     validate_operations,
 )
@@ -29,6 +30,7 @@ __all__ = [
     "UnsupportedPayloadError",
     "ZipMemberSource",
     "extract_partition",
+    "extract_partition_to_stream",
     "open_source",
     "parse_payload",
     "validate_operations",

--- a/src/payload_dumper/cli.py
+++ b/src/payload_dumper/cli.py
@@ -22,6 +22,7 @@ from .core import (
     PayloadError,
     UnsupportedPayloadError,
     extract_partition,
+    extract_partition_to_stream,
     parse_payload,
     partition_op_types,
     validate_operations,
@@ -29,6 +30,7 @@ from .core import (
 from .source import ByteSource, SourceError, describe, open_source
 
 console = Console()
+STDOUT_SENTINEL = "-"
 
 
 def _list_partitions_table(manifest) -> None:
@@ -79,14 +81,16 @@ def _humansize(n: int) -> str:
     return f"{n:.1f} PB"
 
 
-def _select_partitions(manifest, requested: Optional[List[str]]):
+def _select_partitions(
+    manifest, requested: Optional[List[str]], msg_console: Optional[Console] = None
+):
     if not requested:
         return list(manifest.partitions)
     wanted = {p.lower() for p in requested}
     selected = [p for p in manifest.partitions if p.partition_name.lower() in wanted]
     missing = wanted - {p.partition_name.lower() for p in selected}
     if missing:
-        console.print(
+        (msg_console or console).print(
             f"[yellow]warning:[/yellow] partitions not found: "
             f"{', '.join(sorted(missing))}"
         )
@@ -112,7 +116,10 @@ def _parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "-o", "--output", default="output",
-        help="output directory (default: output/)",
+        help=(
+            "output directory (default: output/). Use '-' to stream a single "
+            "partition to stdout; requires exactly one partition via -p."
+        ),
     )
     parser.add_argument(
         "-p", "--partitions", nargs="+", metavar="NAME",
@@ -189,20 +196,64 @@ def _extract_all(source, data_offset, partitions, output_dir, workers) -> List[t
     return failures
 
 
+def _extract_one_to_stdout(
+    source, data_offset, part, err_console: Console
+) -> List[tuple]:
+    """Stream a single partition to sys.stdout.buffer, progress on stderr."""
+    failures: List[tuple] = []
+    total_ops = len(part.operations)
+
+    progress = Progress(
+        TextColumn("[bold cyan]{task.description}"),
+        BarColumn(bar_width=None),
+        MofNCompleteColumn(),
+        TextColumn("ops"),
+        TimeElapsedColumn(),
+        console=err_console,
+        transient=False,
+    )
+
+    with progress:
+        task = progress.add_task(part.partition_name, total=total_ops)
+
+        def advance(n: int) -> None:
+            progress.advance(task, n)
+
+        try:
+            extract_partition_to_stream(
+                source, data_offset, part, sys.stdout.buffer, advance
+            )
+            sys.stdout.buffer.flush()
+        except PayloadError as e:
+            failures.append((part.partition_name, str(e)))
+            err_console.print(f"[red]FAIL[/red] {part.partition_name}: {e}")
+        except Exception as e:
+            failures.append((part.partition_name, repr(e)))
+            err_console.print(f"[red]FAIL[/red] {part.partition_name}: {e!r}")
+
+    return failures
+
+
 def main(argv: Optional[List[str]] = None) -> int:
     args = _parse_args(argv)
+    to_stdout = args.output == STDOUT_SENTINEL
+
+    # When streaming image bytes to stdout, every banner/progress/warning must
+    # go to stderr so the pipe stays uncontaminated. Otherwise reuse the
+    # module-global stdout console.
+    msg_console = Console(stderr=True) if to_stdout else console
 
     try:
         source: ByteSource = open_source(args.payload)
     except (SourceError, FileNotFoundError) as e:
-        console.print(f"[red]error:[/red] {e}")
+        msg_console.print(f"[red]error:[/red] {e}")
         return 1
 
     try:
         try:
             payload = parse_payload(source)
         except PayloadError as e:
-            console.print(f"[red]error:[/red] {e}")
+            msg_console.print(f"[red]error:[/red] {e}")
             return 1
 
         manifest = payload.manifest
@@ -211,11 +262,11 @@ def main(argv: Optional[List[str]] = None) -> int:
             _list_partitions_json(manifest)
             return 0
 
-        console.print(
+        msg_console.print(
             f"[bold]source[/bold]  {describe(args.payload)}  "
             f"size={_humansize(source.size())}"
         )
-        console.print(
+        msg_console.print(
             f"[bold]payload[/bold]  minor_version={manifest.minor_version}  "
             f"block_size={manifest.block_size}  partitions={len(manifest.partitions)}"
         )
@@ -224,20 +275,39 @@ def main(argv: Optional[List[str]] = None) -> int:
             _list_partitions_table(manifest)
             return 0
 
-        partitions = _select_partitions(manifest, args.partitions)
+        partitions = _select_partitions(manifest, args.partitions, msg_console)
         if not partitions:
-            console.print("no partitions to extract")
+            msg_console.print("no partitions to extract")
             return 0
 
         try:
             validate_operations(partitions)
         except UnsupportedPayloadError as e:
-            console.print(f"[red]error:[/red] {e}")
+            msg_console.print(f"[red]error:[/red] {e}")
             return 1
+
+        if to_stdout:
+            if len(partitions) != 1:
+                msg_console.print(
+                    "[red]error:[/red] streaming to stdout (-o -) requires "
+                    "exactly one partition via -p NAME"
+                )
+                return 2
+            msg_console.print(
+                f"streaming [bold]{partitions[0].partition_name}[/bold] to stdout\n"
+            )
+            try:
+                failures = _extract_one_to_stdout(
+                    source, payload.data_offset, partitions[0], msg_console
+                )
+            except KeyboardInterrupt:
+                msg_console.print("\n[yellow]interrupted[/yellow]")
+                return 130
+            return 1 if failures else 0
 
         workers = max(1, min(args.workers, len(partitions)))
         os.makedirs(args.output, exist_ok=True)
-        console.print(
+        msg_console.print(
             f"extracting {len(partitions)} partition(s) to "
             f"[bold]{args.output}/[/bold]  workers={workers}\n"
         )
@@ -247,14 +317,14 @@ def main(argv: Optional[List[str]] = None) -> int:
                 source, payload.data_offset, partitions, args.output, workers
             )
         except KeyboardInterrupt:
-            console.print("\n[yellow]interrupted[/yellow]")
+            msg_console.print("\n[yellow]interrupted[/yellow]")
             return 130
 
         if failures:
-            console.print(f"\n[red]{len(failures)} partition(s) failed[/red]")
+            msg_console.print(f"\n[red]{len(failures)} partition(s) failed[/red]")
             return 1
 
-        console.print(
+        msg_console.print(
             f"\n[green]done[/green]  extracted {len(partitions)} partition(s) "
             f"to {args.output}/"
         )

--- a/src/payload_dumper/core.py
+++ b/src/payload_dumper/core.py
@@ -6,7 +6,7 @@ import lzma
 import os
 import struct
 from dataclasses import dataclass
-from typing import Callable, Iterable, List, Optional
+from typing import BinaryIO, Callable, Iterable, List, Optional
 
 from . import update_metadata_pb2 as um
 from .source import ByteSource
@@ -124,6 +124,44 @@ def _decompress(data: bytes, op_type: int) -> bytes:
     raise ValueError(f"cannot decompress op: {OP_NAMES.get(op_type, op_type)}")
 
 
+def extract_partition_to_stream(
+    source: ByteSource,
+    data_offset: int,
+    part,
+    stream: BinaryIO,
+    on_progress: Optional[Callable[[int], None]] = None,
+) -> None:
+    """Decompress `part` into `stream`, op by op, hashing as we go.
+
+    The stream is written sequentially — it only needs `.write(bytes)`, not
+    seek/tell — so callers can pass a file, `sys.stdout.buffer`, or a pipe.
+    Raises `PayloadError` on hash mismatch (per-op or final image)."""
+    digest = hashlib.sha256()
+    for op in part.operations:
+        if op.type in (OP_ZERO, OP_DISCARD):
+            total = sum(ext.num_blocks for ext in op.dst_extents) * BLOCK_SIZE
+            data = b"\x00" * total
+        else:
+            raw = source.read_at(data_offset + op.data_offset, op.data_length)
+            if (
+                op.data_sha256_hash
+                and hashlib.sha256(raw).digest() != op.data_sha256_hash
+            ):
+                raise PayloadError(
+                    f"{part.partition_name}: operation data hash mismatch"
+                )
+            data = _decompress(raw, op.type)
+
+        digest.update(data)
+        stream.write(data)
+        if on_progress is not None:
+            on_progress(1)
+
+    expected = part.new_partition_info.hash
+    if expected and digest.digest() != expected:
+        raise PayloadError(f"{part.partition_name}: final image hash mismatch")
+
+
 def extract_partition(
     source: ByteSource,
     data_offset: int,
@@ -138,32 +176,8 @@ def extract_partition(
     invoked once per completed operation.
     """
     out_path = os.path.join(output_dir, f"{part.partition_name}.img")
-    digest = hashlib.sha256()
-
     with open(out_path, "wb") as out_file:
-        for op in part.operations:
-            if op.type in (OP_ZERO, OP_DISCARD):
-                total = sum(ext.num_blocks for ext in op.dst_extents) * BLOCK_SIZE
-                data = b"\x00" * total
-            else:
-                raw = source.read_at(data_offset + op.data_offset, op.data_length)
-                if (
-                    op.data_sha256_hash
-                    and hashlib.sha256(raw).digest() != op.data_sha256_hash
-                ):
-                    raise PayloadError(
-                        f"{part.partition_name}: operation data hash mismatch"
-                    )
-                data = _decompress(raw, op.type)
-
-            digest.update(data)
-            out_file.write(data)
-            if on_progress is not None:
-                on_progress(1)
-
-    expected = part.new_partition_info.hash
-    if expected and digest.digest() != expected:
-        raise PayloadError(f"{part.partition_name}: final image hash mismatch")
+        extract_partition_to_stream(source, data_offset, part, out_file, on_progress)
     return out_path
 
 

--- a/tests/test_stdout_streaming.py
+++ b/tests/test_stdout_streaming.py
@@ -1,0 +1,126 @@
+"""Tests for `-o -` stdout streaming mode."""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from payload_dumper.cli import main
+from payload_dumper.core import (
+    PayloadError,
+    extract_partition_to_stream,
+    parse_payload,
+)
+from payload_dumper.source import FileSource
+
+
+class TestExtractToStream:
+    """Unit tests against extract_partition_to_stream — the building block."""
+
+    def test_stream_output_matches_file_output(self, multi_payload_file, tmp_path):
+        # file-based extract as reference
+        from payload_dumper.core import extract_partition
+        src = FileSource(multi_payload_file)
+        try:
+            payload = parse_payload(src)
+            out_dir = tmp_path / "disk"
+            out_dir.mkdir()
+            part = next(p for p in payload.manifest.partitions if p.partition_name == "system")
+            disk_path = extract_partition(src, payload.data_offset, part, str(out_dir))
+            disk_bytes = open(disk_path, "rb").read()
+
+            # stream into BytesIO, compare
+            buf = io.BytesIO()
+            extract_partition_to_stream(src, payload.data_offset, part, buf)
+            assert buf.getvalue() == disk_bytes
+        finally:
+            src.close()
+
+    def test_stream_progress_callback_fires_per_op(self, multi_payload_file):
+        src = FileSource(multi_payload_file)
+        try:
+            payload = parse_payload(src)
+            part = next(p for p in payload.manifest.partitions if p.partition_name == "system")
+            calls: list[int] = []
+            extract_partition_to_stream(
+                src, payload.data_offset, part, io.BytesIO(), calls.append
+            )
+            assert sum(calls) == len(part.operations)
+        finally:
+            src.close()
+
+    def test_stream_hash_mismatch_raises(self, multi_payload_file):
+        src = FileSource(multi_payload_file)
+        try:
+            payload = parse_payload(src)
+            part = payload.manifest.partitions[0]
+            part.new_partition_info.hash = b"\x00" * 32
+            with pytest.raises(PayloadError, match="final image hash mismatch"):
+                extract_partition_to_stream(src, payload.data_offset, part, io.BytesIO())
+        finally:
+            src.close()
+
+
+class TestCliStdout:
+    """End-to-end tests for `payload-dumper -o -`."""
+
+    def test_stdout_bytes_match_disk_extract(
+        self, multi_payload_file, tmp_path, capsysbinary
+    ):
+        """Pure image bytes land on stdout; matches what `-o <dir>` writes."""
+        # Reference: extract to disk
+        out_dir = tmp_path / "ref"
+        assert main([multi_payload_file, "-o", str(out_dir), "-p", "boot", "-j", "1"]) == 0
+        reference = (out_dir / "boot.img").read_bytes()
+        capsysbinary.readouterr()  # drain captured output from the disk run
+
+        # Now stream the same partition to stdout
+        rc = main([multi_payload_file, "-o", "-", "-p", "boot"])
+        assert rc == 0
+        captured = capsysbinary.readouterr()
+        assert captured.out == reference
+
+    def test_stdout_mode_keeps_banner_out_of_pipe(
+        self, multi_payload_file, capsysbinary
+    ):
+        """Banner/progress must go to stderr so stdout stays clean."""
+        rc = main([multi_payload_file, "-o", "-", "-p", "boot"])
+        assert rc == 0
+        captured = capsysbinary.readouterr()
+        # image bytes should start with whatever `boot.img` starts with —
+        # definitely not the string "source" / "payload" from the banner
+        assert b"source" not in captured.out[:200]
+        assert b"payload" not in captured.out[:200]
+        # banner did land somewhere — on stderr
+        assert b"source" in captured.err or b"payload" in captured.err
+
+    def test_stdout_without_partition_flag_errors(self, multi_payload_file, capsys):
+        rc = main([multi_payload_file, "-o", "-"])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "exactly one partition" in err
+
+    def test_stdout_with_multiple_partitions_errors(self, multi_payload_file, capsys):
+        rc = main([multi_payload_file, "-o", "-", "-p", "boot", "system"])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "exactly one partition" in err
+
+    def test_stdout_with_unknown_partition_errors(self, multi_payload_file, capsys):
+        """Warning filters the selection down to 0; we should not silently succeed."""
+        rc = main([multi_payload_file, "-o", "-", "-p", "nope"])
+        # 0 partitions matched — falls out before reaching the stdout path
+        assert rc == 0  # matches existing "no partitions to extract" behavior
+        out = capsys.readouterr()
+        assert "nope" in (out.err + out.out)
+
+    def test_stdout_mode_still_validates_delta_payload(
+        self, tmp_path, delta_payload, capsys
+    ):
+        p = tmp_path / "delta.bin"
+        p.write_bytes(delta_payload)
+        rc = main([str(p), "-o", "-", "-p", "system"])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "SOURCE_COPY" in err


### PR DESCRIPTION
## Summary
Adds an `-o -` mode that writes one partition's image bytes directly to stdout instead of to a file in the output directory. Lets users pipe straight into `simg2img`, `fastboot`, or any other tool:

    payload-dumper ota.zip -p boot -o - | fastboot flash boot -
    payload-dumper payload.bin -p system -o - | simg2img - system.raw

## Implementation
- New `extract_partition_to_stream(...)` in `core.py` takes any writable `BinaryIO` and does the full op-by-op decompress + hash-verify. The existing `extract_partition(...)` is now a thin wrapper that opens the target file and delegates — one code path, same semantics.
- CLI `-o -` mode requires exactly one partition via `-p` (anything else would be ambiguous) and routes every Rich banner/progress frame to a stderr console so stdout stays pure image bytes. Writes to `sys.stdout.buffer` to bypass text-mode translation on Windows.

## Test plan
- [x] 9 new tests under `tests/test_stdout_streaming.py` covering byte-identical output vs disk extraction, stdout-vs-stderr separation, validation errors (no `-p`, multiple `-p`), and delta-payload rejection still firing in stdout mode.
- [x] Full suite: `uv run pytest` — 48 passed locally.