### PR TITLE
Release v2.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "android-payload-dumper"
-version = "2.2.0"
+version = "2.3.0"
 description = "Extract partition images from Android OTA payload.bin files — locally, from a URL, or straight from an OTA .zip"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/payload_dumper/__init__.py
+++ b/src/payload_dumper/__init__.py
@@ -18,7 +18,7 @@ from .source import (
     open_source,
 )
 
-__version__ = "2.2.0"
+__version__ = "2.3.0"
 
 __all__ = [
     "ByteSource",

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "android-payload-dumper"
-version = "2.2.0"
+version = "2.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Bump version to 2.3.0

## What's in this release
- **Test suite** â€” 48 pytest tests covering source, core, CLI, and stdout streaming, with CrAU payloads synthesized in-memory (no canned binaries)
- **CI** â€” GitHub Actions matrix across Ubuntu/macOS/Windows Ã— Python 3.9 and 3.12 on every push
- **Python 3.9 minimum** â€” bumped from 3.8 (pytest 9.x requires it)
- **Stdout streaming** â€” `-o -` pipes a single partition's image to stdout for composition with `simg2img`, `fastboot`, etc.

## Test plan
- [x] CI green on `tests/pytest-suite` (PR #4)
- [x] CI green on `feat/stdout-streaming` (PR #5)
- [ ] Tag `v2.3.0` on main after merge to trigger release workflow (GitHub release + PyPI publish)
